### PR TITLE
Set biopython version dependency to >=1.66,<=1.76

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
                       'By default, reports both the homoplasic events and '
                       'all mutation events. Also maps the SNPs to the tree.'),
     install_requires=[
-        'biopython>=1.66',
+        'biopython>=1.66,<=1.76',
         'ete3',
         'phylo-treetime'
     ],


### PR DESCRIPTION
Required by current version of phylo-treetime. Closes #20