### PR TITLE
modified code to ignore missing calls, resulting in substantial speedup

### DIFF
--- a/scripts/snppar.py
+++ b/scripts/snppar.py
@@ -2664,6 +2664,20 @@ def main():
 		logPrint(log, message, 'INFO')
 		writeMFASTA(prefix+"node_sequences.fasta",node_snptable,tree_nodes)
 		mapped = getConsequences(mapped, snptable, strains, node_snptable, tree_nodes, sequence, snpPositionList,log)
+		
+	####### modified by Roger Vargas Jr #################################
+	#split mapped variants up into intragenic and intergenic
+	mapped_intragenic_variants = [mapped_variant for mapped_variant in mapped if mapped_variant[1]=='intragenic']
+	mapped_intergenic_variants = [mapped_variant for mapped_variant in mapped if mapped_variant[1]=='intergenic']
+
+    #keep only mapped variants if neither Ancestor Allele or Derived Allele is an 'N'
+	mapped_intragenic_variants_to_keep = [mapped_variant for mapped_variant in mapped_intragenic_variants if (mapped_variant[8] != 'N') and (mapped_variant[9] != 'N')]
+	mapped_intergenic_variants_to_keep = [mapped_variant for mapped_variant in mapped_intergenic_variants if (mapped_variant[10] != 'N') and (mapped_variant[11] != 'N')]
+
+	#merge intragenic and intergenic into same list
+	mapped = mapped_intragenic_variants_to_keep + mapped_intergenic_variants_to_keep
+	##################################################################
+	
 	findEvents(arguments.mutation_events,arguments.strict, arguments.no_all_calls, arguments.parallel, arguments.convergent, arguments.revertant, arguments.no_homoplasic, arguments.no_all_events, mapped, prefix, tree, tree_strains,log)
 	if not arguments.no_clean_up and not arguments.mutation_events:
 		cleanUp(directory,prefix,arguments.fastml,log)


### PR DESCRIPTION
This commit contains a fix by Roger Vargas Jr. that ignores missing calls, resulting in major speedups. I added the fix to the most recent version of SNPpar, because Roger made his changes in 2020. Explanation below from Roger (@vargasr39):

---
Since SNPPar treats each missing/ambiguous call as a mutation event, the program kept getting stuck in the while loop inside the findEvents() function. The program sometimes doesn't terminate on large sample sizes as a result of getting stuck on this step if the input SNP table has a sizable number of missing calls. 

For example, on a sample of Mtb L1 isolates we have: 
Lineage 1: 766 isolates, 21790 SNPs
    Runtime = 30 hours & 50 minutes
    missing calls: 249,629 or 1.5% of calls
    flags: --sorting intermediate --all_homoplasic_types

Since I didn't care about the reporting or classifying of the missing calls I modified the snppar.py script a bit to remove all of these calls from the mapped list under the main() function (code attached). This significantly improved the runtime and all of my runs ended up finishing much quicker (sometimes terminating in ~2% of the original runtime). 

The example above with the modified script: 
Lineage 1: 766 isolates, 21790 SNPs
    Runtime = 25 minutes
    missing calls: 249,629 or 1.5% of calls
    flags: --sorting intermediate --no_all_calls --no_homoplasic

I also suppressed the homoplasic reporting for these runs since I was mainly interested in parallel mutations and that's easily parsed from the all_mutation_events.tsv file.
